### PR TITLE
fix: correct previous file navigation logic

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,11 +216,17 @@ export const activate = (context: vscode.ExtensionContext) => {
             );
 
             // Return the next/previous file
-            return filesSorted[
-                activeFileIndex === -1
-                    ? 0
-                    : (activeFileIndex + 1) % filesSorted.length
-            ];
+            const modifier = direction === "next" ? 1 : -1;
+            let nextFileIndex;
+            if (activeFileIndex === -1) {
+                nextFileIndex =
+                    direction === "next" ? 0 : filesSorted.length - 1;
+            } else {
+                nextFileIndex =
+                    (activeFileIndex + modifier + filesSorted.length) %
+                    filesSorted.length;
+            }
+            return filesSorted[nextFileIndex];
         };
         const [uri, diagnostics] = getNextFile();
 


### PR DESCRIPTION
# Bug Fix Description

## Bug Summary
Previously, the file navigation logic in the extension did not properly handle "previous" direction and wrap-around indexing. For example, attempting to go to the previous file from the first one or looping back from the last to the first was not implemented correctly, potentially causing incorrect file selection or errors.

## Fix Details
- Added support for direction modifier (1 for next, -1 for previous).
- Adjusted index calculation to handle negative indices and wrap-around using modulo operation: `(activeFileIndex + modifier + filesSorted.length) % filesSorted.length`.
- Handled cases where active file is not found (e.g., start from 0 for next or last for previous).

This ensures seamless navigation in both directions with circular behavior.

## Impact
This fix improves user experience by allowing proper cycling through diagnostic files without getting stuck or selecting wrong files. It prevents potential runtime errors in edge cases.